### PR TITLE
Add InfraNode (keyless open-data API + MCP server for German cities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ This list is about [fiscal financed public projects](https://publiccode.eu/) or 
 ## APIs
 
 - [bund.dev](https://bund.dev/): German government APIs (documented by the civic tech community)
-- [InfraNode](https://infranode.dev/): Free, keyless REST API and MCP server for open data of 84 German cities (weather, DWD warnings, air quality, public transit, traffic, water levels, energy/SMARD, statistics), Apache-2.0
 
 ## Mobile apps
 
@@ -62,6 +61,7 @@ This list is about [fiscal financed public projects](https://publiccode.eu/) or 
 
 - [OParl](https://github.com/OParl/): Open standard for machine-readable access to municipal council information systems
 - [meine-stadt-transparent](https://github.com/meine-stadt-transparent/meine-stadt-transparent/): A website to bring municipal politics to citizens
+- [InfraNode](https://infranode.dev/): Free, keyless REST API and MCP server for open data of 84 German cities (weather, DWD warnings, air quality, public transit, traffic, water levels, energy/SMARD, statistics), Apache-2.0
 - [Consul](https://github.com/consul/consul): Open government and e-participation web software
 - [ckan](https://ckan.org/): Open Data portal management system
 - [piveau](https://www.piveau.de/): Open Data portal management system

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This list is about [fiscal financed public projects](https://publiccode.eu/) or 
 ## APIs
 
 - [bund.dev](https://bund.dev/): German government APIs (documented by the civic tech community)
+- [InfraNode](https://infranode.dev/): Free, keyless REST API and MCP server for open data of 84 German cities (weather, DWD warnings, air quality, public transit, traffic, water levels, energy/SMARD, statistics), Apache-2.0
 
 ## Mobile apps
 


### PR DESCRIPTION
Adds [InfraNode](https://infranode.dev/) to the APIs section.

InfraNode is a free, keyless REST API and MCP server that normalises open public data for 84 German cities (weather, DWD severe-weather warnings, air quality, public transit incl. realtime departures, traffic, water levels/flood, energy and the SMARD electricity market, demographics, elections and more) behind one consistent interface. No API key, no signup. Open source (Apache-2.0), and listed in the official MCP Registry.

One line added under `## APIs`, alphabetical order kept.